### PR TITLE
Validate /dose-calculation parameters

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,12 +13,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+env:
+  apikey: ${{ secrets.apikey }}
+  MONGO_URL: ${{ secrets.MONGO_URL }}
 
 jobs:
   build:
-    env:
-        apikey: ${{ secrets.apikey }}
-        MONGO_URL: ${{ secrets.MONGO_URL }}
         
     runs-on: ubuntu-latest
     
@@ -35,4 +35,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Dapikey=$apikey -DMONGO_URL=$MONGO_URL

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,10 @@ on:
 
 jobs:
   build:
-
+    env:
+        apikey: ${{ secrets.apikey }}
+        MONGO_URL: ${{ secrets.MONGO_URL }}
+        
     runs-on: ubuntu-latest
     
     defaults:

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsController.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsController.java
@@ -8,9 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
-
-import fi.tuni.koodimankelit.antibiootit.models.Parameters;
 import fi.tuni.koodimankelit.antibiootit.models.Treatments;
+import fi.tuni.koodimankelit.antibiootit.models.request.Parameters;
 import fi.tuni.koodimankelit.antibiootit.services.AntibioticsService;
 import fi.tuni.koodimankelit.antibiootit.database.data.DiagnoseInfo;
 

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/DatabaseTestController.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/DatabaseTestController.java
@@ -22,12 +22,18 @@ public class DatabaseTestController {
     // TEST ONLY
     @PostMapping("/database-search")
     public Diagnose getDiagnoseByID() {
-        return dataHandler.getDiagnoseById("J21.9");
+        return dataHandler.getDiagnoseById("J03.0");
     }
     
     // TEST ONLY
     @PostMapping("/get-diagnoseinfos")
         public List<DiagnoseInfo> getDiagnoseInfos() {
         return dataHandler.getAllDiagnoseInfos();
+    }
+
+    // TEST ONLY
+    @PostMapping("/get-diagnoseinfo")
+    public DiagnoseInfo getDiagnosisInfo() {
+        return dataHandler.getDiagnosisInfoById("J03.0");
     }
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/database/DiagnoseRepository.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/database/DiagnoseRepository.java
@@ -15,4 +15,6 @@ public interface DiagnoseRepository extends MongoRepository<Diagnose, String> {
     @Query(value = "{}", fields = "{'_id': 1, 'name': 1, 'etiology': 1, 'checkBoxes': 1}")
     List<DiagnoseInfo> getAllDiagnoseInfos();
 
+    @Query("{_id: '?0'}")
+    DiagnoseInfo getDiagnosisInfoById(String id);
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/InfectionSelection.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/InfectionSelection.java
@@ -1,0 +1,31 @@
+package fi.tuni.koodimankelit.antibiootit.models.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class InfectionSelection {
+
+    @NotBlank(message = "Infection ID is mandatory")
+    private final String id;
+
+    @NotNull(message = "Selection is mandatory")
+    private final boolean value;
+
+
+    public InfectionSelection(String id, boolean value) {
+        this.id = id;
+        this.value = value;
+    }
+
+
+    public String getId() {
+        return this.id;
+    }
+
+
+    public boolean getValue() {
+        return this.value;
+    }
+
+
+}

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
@@ -1,4 +1,4 @@
-package fi.tuni.koodimankelit.antibiootit.models;
+package fi.tuni.koodimankelit.antibiootit.models.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
@@ -1,5 +1,7 @@
 package fi.tuni.koodimankelit.antibiootit.models.request;
 
+import java.util.List;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -16,14 +18,14 @@ public class Parameters {
     private final Boolean penicillinAllergic;
 
     @NotNull(message = "Ebv is mandatory")
-    private final Boolean ebv;
+    private final List<InfectionSelection> checkBoxes;
 
 
-    public Parameters(String diagnosisID, Double weight, Boolean penicillinAllergic, Boolean ebv) {
+    public Parameters(String diagnosisID, Double weight, Boolean penicillinAllergic, List<InfectionSelection> checkBoxes) {
         this.diagnosisID = diagnosisID;
         this.weight = weight;
         this.penicillinAllergic = penicillinAllergic;
-        this.ebv = ebv;
+        this.checkBoxes = checkBoxes;
     }
 
 
@@ -40,19 +42,9 @@ public class Parameters {
     public boolean getPenicillinAllergic() {
         return this.penicillinAllergic;
     }
-
-
-    public boolean getEbv() {
-        return this.ebv;
-    }
-
-
-
-    @Override
-    // For testing purposes
-    public String toString() {
-        return String.format("Parameters{%s %.1f PenicillinAllergic: %s Ebv: %s}", diagnosisID, weight, penicillinAllergic, ebv);
-    }
     
-
+    
+    public List<InfectionSelection> getCheckBoxes() {
+        return this.checkBoxes;
+    }
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/models/request/Parameters.java
@@ -17,7 +17,7 @@ public class Parameters {
     @NotNull(message = "PenicillinAllergic is mandatory")
     private final Boolean penicillinAllergic;
 
-    @NotNull(message = "Ebv is mandatory")
+    @NotNull(message = "CheckBoxes is mandatory")
     private final List<InfectionSelection> checkBoxes;
 
 

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsService.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsService.java
@@ -13,4 +13,6 @@ public interface AntibioticsService {
     public Treatments calculateTreatments(Parameters parameters);
 
     public List<DiagnoseInfo> getAllDiagnoseInfos();
+
+    public DiagnoseInfo getDiagnoseInfoByID(String id);
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsService.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsService.java
@@ -3,8 +3,8 @@ package fi.tuni.koodimankelit.antibiootit.services;
 import java.util.List;
 
 import fi.tuni.koodimankelit.antibiootit.database.data.DiagnoseInfo;
-import fi.tuni.koodimankelit.antibiootit.models.Parameters;
 import fi.tuni.koodimankelit.antibiootit.models.Treatments;
+import fi.tuni.koodimankelit.antibiootit.models.request.Parameters;
 
 
 public interface AntibioticsService {

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
@@ -10,9 +10,9 @@ import fi.tuni.koodimankelit.antibiootit.models.DosageFormula;
 import fi.tuni.koodimankelit.antibiootit.models.DosageResult;
 import fi.tuni.koodimankelit.antibiootit.models.Instructions;
 import fi.tuni.koodimankelit.antibiootit.models.Measurement;
-import fi.tuni.koodimankelit.antibiootit.models.Parameters;
 import fi.tuni.koodimankelit.antibiootit.models.Treatment;
 import fi.tuni.koodimankelit.antibiootit.models.Treatments;
+import fi.tuni.koodimankelit.antibiootit.models.request.Parameters;
 
 @Service
 public class AntibioticsServiceImpl implements AntibioticsService {

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
@@ -56,4 +56,10 @@ public class AntibioticsServiceImpl implements AntibioticsService {
         return d;
     }
 
+    @Override
+    public DiagnoseInfo getDiagnoseInfoByID(String id) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getDiagnoseInfoByID'");
+    }
+
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/AntibioticsServiceImpl.java
@@ -58,8 +58,7 @@ public class AntibioticsServiceImpl implements AntibioticsService {
 
     @Override
     public DiagnoseInfo getDiagnoseInfoByID(String id) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getDiagnoseInfoByID'");
+        return dataHandler.getDiagnosisInfoById(id);
     }
 
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/DataHandler.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/DataHandler.java
@@ -14,5 +14,7 @@ public interface DataHandler {
     public Diagnose getDiagnoseById(String id);
 
     public List<DiagnoseInfo> getAllDiagnoseInfos();
+
+    public DiagnoseInfo getDiagnosisInfoById(String id);
     
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/DataHandlerImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/services/DataHandlerImpl.java
@@ -30,5 +30,10 @@ public class DataHandlerImpl implements DataHandler {
     public List<DiagnoseInfo> getAllDiagnoseInfos() {
         return repository.getAllDiagnoseInfos();
     }
+
+    @Override
+    public DiagnoseInfo getDiagnosisInfoById(String id) {
+        return repository.getDiagnosisInfoById(id);
+    }
     
 }

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/AntibioticsServiceTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/AntibioticsServiceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import fi.tuni.koodimankelit.antibiootit.models.Parameters;
+import fi.tuni.koodimankelit.antibiootit.models.request.Parameters;
 import fi.tuni.koodimankelit.antibiootit.services.AntibioticsService;
 
 @SpringBootTest

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/AntibioticsServiceTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/AntibioticsServiceTest.java
@@ -2,6 +2,8 @@ package fi.tuni.koodimankelit.antibiootit;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,7 +25,7 @@ public class AntibioticsServiceTest {
     public void testCalculateTreatments() {
 
         // Test not implemented, used to verify that GitHub CI/CD pipeline works
-        Parameters params = new Parameters("test-id", 20.0, false, false);
+        Parameters params = new Parameters("test-id", 20.0, false, new ArrayList<>());
         var result = antibioticsService.calculateTreatments(params);
         assertNotNull(result);
     }


### PR DESCRIPTION
Implemented custom validator for /dose-calculation parameters.
"checkBoxes" list must contain all required checkboxes for the diagnosis.
Error 400 Bad Request is returned if validation fails. Error message contains all the required checkbox IDs.

Other parameters have already validation implemented by annotations.