### PR TITLE
Implemented Cross Origin support for API

### DIFF
--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/ApiKeyConfig.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/ApiKeyConfig.java
@@ -1,6 +1,5 @@
 package fi.tuni.koodimankelit.antibiootit.config;
 
-import org.junit.jupiter.api.Order;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +9,6 @@ import org.springframework.context.annotation.PropertySource;
 import fi.tuni.koodimankelit.antibiootit.filter.ApiKeyFilter;
 
 @Configuration
-@Order(2)
 @PropertySource(value = "classpath:secrets.properties", ignoreResourceNotFound = true)
 public class ApiKeyConfig {
 
@@ -22,6 +20,7 @@ public class ApiKeyConfig {
         FilterRegistrationBean<ApiKeyFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new ApiKeyFilter(apiKeySecret));
         registrationBean.addUrlPatterns("/api/antibiotics/*");
+        registrationBean.setOrder(2);
         return registrationBean;
     }
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/ApiKeyConfig.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/ApiKeyConfig.java
@@ -1,14 +1,16 @@
 package fi.tuni.koodimankelit.antibiootit.config;
 
+import org.junit.jupiter.api.Order;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
-import fi.tuni.koodimankelit.antibiootit.authentication.ApiKeyFilter;
+import fi.tuni.koodimankelit.antibiootit.filter.ApiKeyFilter;
 
 @Configuration
+@Order(2)
 @PropertySource(value = "classpath:secrets.properties", ignoreResourceNotFound = true)
 public class ApiKeyConfig {
 
@@ -16,7 +18,7 @@ public class ApiKeyConfig {
     private String apiKeySecret;
 
     @Bean
-    public FilterRegistrationBean<ApiKeyFilter> requestFilter() {
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilter() {
         FilterRegistrationBean<ApiKeyFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new ApiKeyFilter(apiKeySecret));
         registrationBean.addUrlPatterns("/api/antibiotics/*");

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/CorsConfig.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/CorsConfig.java
@@ -1,9 +1,9 @@
 package fi.tuni.koodimankelit.antibiootit.config;
 
-import org.junit.jupiter.api.Order;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 
 import fi.tuni.koodimankelit.antibiootit.filter.CorsFilter;
 
@@ -15,7 +15,8 @@ public class CorsConfig {
     public FilterRegistrationBean<CorsFilter> corsFilter() {
         FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new CorsFilter());
-        registrationBean.addUrlPatterns("*");
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(1);
         return registrationBean;
     }
     

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/CorsConfig.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package fi.tuni.koodimankelit.antibiootit.config;
+
+import org.junit.jupiter.api.Order;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import fi.tuni.koodimankelit.antibiootit.filter.CorsFilter;
+
+@Configuration
+@Order(1)
+public class CorsConfig {
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilter() {
+        FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new CorsFilter());
+        registrationBean.addUrlPatterns("*");
+        return registrationBean;
+    }
+    
+}

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/ApiKeyFilter.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/ApiKeyFilter.java
@@ -30,13 +30,6 @@ public class ApiKeyFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        // Allow OPTIONS requests without API key
-        if (httpRequest.getMethod().equals("OPTIONS")) {
-            httpResponse.setStatus(HttpServletResponse.SC_OK);
-            chain.doFilter(request, response);
-            return;
-        }
-
 
         String headerValue = httpRequest.getHeader(HEADER_NAME);
 

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/ApiKeyFilter.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/ApiKeyFilter.java
@@ -1,4 +1,4 @@
-package fi.tuni.koodimankelit.antibiootit.authentication;
+package fi.tuni.koodimankelit.antibiootit.filter;
 
 import java.io.IOException;
 
@@ -30,13 +30,20 @@ public class ApiKeyFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
+        // Allow OPTIONS requests without API key
+        if (httpRequest.getMethod().equals("OPTIONS")) {
+            httpResponse.setStatus(HttpServletResponse.SC_OK);
+            chain.doFilter(request, response);
+            return;
+        }
+
+
         String headerValue = httpRequest.getHeader(HEADER_NAME);
 
         if(headerValue == null || !headerValue.equals(apiKeySecret)) {
             httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
-        
         
         chain.doFilter(request, response);
         

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/CorsFilter.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/CorsFilter.java
@@ -1,0 +1,28 @@
+package fi.tuni.koodimankelit.antibiootit.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CorsFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // Add required CORS headers
+        httpResponse.setHeader("Access-Control-Allow-Origin", "*");
+        httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST");
+        httpResponse.setHeader("Access-Control-Allow-Headers", "X-API-KEY, Content-Type");
+
+        chain.doFilter(request, response);
+    }
+    
+}

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/CorsFilter.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/filter/CorsFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class CorsFilter implements Filter {
@@ -15,12 +16,19 @@ public class CorsFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         // Add required CORS headers
         httpResponse.setHeader("Access-Control-Allow-Origin", "*");
         httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST");
         httpResponse.setHeader("Access-Control-Allow-Headers", "X-API-KEY, Content-Type");
+
+        // Allow OPTIONS requests as they are
+        if (httpRequest.getMethod().equals("OPTIONS")) {
+            httpResponse.setStatus(HttpServletResponse.SC_OK);
+            return;
+        }
 
         chain.doFilter(request, response);
     }

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AuthorizationTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AuthorizationTest.java
@@ -7,7 +7,7 @@ import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import fi.tuni.koodimankelit.antibiootit.authentication.ApiKeyFilter;
+import fi.tuni.koodimankelit.antibiootit.filter.ApiKeyFilter;
 import fi.tuni.koodimankelit.antibiootit.models.Diagnoses;
 
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Should be functional based on my own tests. Allows OPTIONS requests always (CORS), requires API key from all other requests.
Adds required CORS headers to all responses.

Add me to pull request to main and maybe other backend members so they can check it if they want to.