### PR TITLE
Payload parse error returns HTTP 400 instead of 500

### DIFF
--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsController.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsController.java
@@ -3,6 +3,7 @@ package fi.tuni.koodimankelit.antibiootit.controllers;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.RequestBody;
 import jakarta.validation.Valid;
 import fi.tuni.koodimankelit.antibiootit.models.Diagnoses;
@@ -76,4 +77,11 @@ public interface AntibioticsController {
      * @return Map<String, String> Error message
      */
     public Map<String, String> handleDiagnosisNotFoundException(DiagnosisNotFoundException ex);
+
+    /**
+     * Handle HttpMessageNotReadableException and return HTTP 400
+     * @param ex HttpMessageNotReadableException
+     * @return Map<String, String> Error message
+     */
+    public Map<String, String> handleNotValidMessageException(HttpMessageNotReadableException ex);
 }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -100,6 +101,15 @@ public class AntibioticsControllerImpl implements AntibioticsController {
     @ExceptionHandler(DiagnosisNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public Map<String, String> handleDiagnosisNotFoundException(DiagnosisNotFoundException ex) {
+        Map<String, String> errorMap = new HashMap<>();
+        errorMap.put("Error", ex.getMessage());
+        return errorMap;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Override
+    public Map<String, String> handleNotValidMessageException(HttpMessageNotReadableException ex) {
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Error", ex.getMessage());
         return errorMap;

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
@@ -94,6 +94,7 @@ public class AntibioticsControllerImpl implements AntibioticsController {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Object> handleRuntimeException(RuntimeException ex) {
+        System.out.println(ex); // Log exceptions
         return ResponseEntity.internalServerError().build();
 
     }

--- a/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
+++ b/backend/antibiootit/src/main/java/fi/tuni/koodimankelit/antibiootit/controllers/AntibioticsControllerImpl.java
@@ -47,6 +47,7 @@ public class AntibioticsControllerImpl implements AntibioticsController {
     }
 
     @PostMapping("/dose-calculation")
+    @Override
     public DiagnosisResponse doseCalculation(@RequestBody @Valid Parameters parameters) {
         
         String diagnosisID = parameters.getDiagnosisID();
@@ -62,17 +63,20 @@ public class AntibioticsControllerImpl implements AntibioticsController {
     }
 
     @GetMapping("/diagnoses")
+    @Override
     public Diagnoses getDiagnoses() {
         return this.antibioticsService.getAllDiagnosisInfos();
     }
 
     @GetMapping("/info-texts")
+    @Override
     public InfoTexts getInfoTexts() {
         return this.antibioticsService.getAllInfoTexts();
     }
 
     @ExceptionHandler(InvalidParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Override
     public Map<String, String> handleInvalidParameterException(InvalidParameterException ex) {
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Error", ex.getMessage());
@@ -81,6 +85,7 @@ public class AntibioticsControllerImpl implements AntibioticsController {
 
     @ExceptionHandler(NoAntibioticTreatmentException.class)
     @ResponseStatus(HttpStatus.OK)
+    @Override
     public ResponseEntity<NoAntibioticTreatment> handleNoAntiobiticTreatmentException(NoAntibioticTreatmentException ex) {
         
         HttpHeaders headers = new HttpHeaders();
@@ -93,6 +98,7 @@ public class AntibioticsControllerImpl implements AntibioticsController {
     }
 
     @ExceptionHandler(RuntimeException.class)
+    @Override
     public ResponseEntity<Object> handleRuntimeException(RuntimeException ex) {
         System.out.println(ex); // Log exceptions
         return ResponseEntity.internalServerError().build();
@@ -101,6 +107,7 @@ public class AntibioticsControllerImpl implements AntibioticsController {
 
     @ExceptionHandler(DiagnosisNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
+    @Override
     public Map<String, String> handleDiagnosisNotFoundException(DiagnosisNotFoundException ex) {
         Map<String, String> errorMap = new HashMap<>();
         errorMap.put("Error", ex.getMessage());

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
@@ -114,6 +114,15 @@ public class DoseCalculationTest extends AntibioticsControllerTest {
         .andReturn();
     }
 
+    @Test
+    public void invalidPayloadShouldReturn400() throws Exception {
+
+        String payload = "{\"diagnosisID\":\"J03.0\",\"weight\":0.0,\"checkBoxes\":[]"; // Missing end }
+
+        request(payload)
+        .andExpect(status().isBadRequest());
+    }
+
 
 
     private ResultActions request(Parameters parameters) throws Exception {


### PR DESCRIPTION
Implemented error handling for API requests where payload (body) isn't valid JSON. Returns 400 Bad request instead of 500 internal server error. Also created a test for this. 

Also added @Override annotation to all Controller methods that are defined in interface.
Also added printing of RuntimeExceptions. The handler is only defined for unit tests, normally these errors would be printed and handled as 500 automatically. It was hard to debug without this print.