### PR TITLE
Refactored tests

### DIFF
--- a/backend/antibiootit/pom.xml
+++ b/backend/antibiootit/pom.xml
@@ -63,11 +63,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>4.0.1</version>

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AntibioticsControllerTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AntibioticsControllerTest.java
@@ -1,34 +1,16 @@
 package fi.tuni.koodimankelit.antibiootit.controller;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-
-import java.util.ArrayList;
-
 import fi.tuni.koodimankelit.antibiootit.controllers.AntibioticsController;
-import fi.tuni.koodimankelit.antibiootit.database.data.DiagnosisInfo;
-import fi.tuni.koodimankelit.antibiootit.models.DiagnosisResponse;
-import fi.tuni.koodimankelit.antibiootit.models.request.InfectionSelection;
-import fi.tuni.koodimankelit.antibiootit.models.request.Parameters;
 import fi.tuni.koodimankelit.antibiootit.services.AntibioticsService;
 import fi.tuni.koodimankelit.antibiootit.validator.CheckBoxValidator;
 

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AuthorizationTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/AuthorizationTest.java
@@ -12,7 +12,6 @@ import fi.tuni.koodimankelit.antibiootit.models.Diagnoses;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -46,7 +45,7 @@ public class AuthorizationTest extends AntibioticsControllerTest {
         mockMvc.perform(
             get(ADDRESS)
             .header("X-API-KEY", "false-apikey")
-        ).andDo(print())
+        )
         .andExpect(status().isUnauthorized());
     }
 
@@ -55,7 +54,7 @@ public class AuthorizationTest extends AntibioticsControllerTest {
 
         mockMvc.perform(
             get(ADDRESS)
-        ).andDo(print())
+        )
         .andExpect(status().isUnauthorized());
     }
 
@@ -65,7 +64,7 @@ public class AuthorizationTest extends AntibioticsControllerTest {
         mockMvc.perform(
             get(ADDRESS)
             .header("Authorization", "Basic someValue")
-        ).andDo(print())
+        )
         .andExpect(status().isUnauthorized());
     }
 

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DiagnosesTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DiagnosesTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +42,6 @@ public class DiagnosesTest extends AntibioticsControllerTest {
             get(ADDRESS))
 
             // Response is ok
-            .andDo(print())
             .andExpect(status().isOk())
             .andReturn();
 

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -45,7 +44,7 @@ public class DoseCalculationTest extends AntibioticsControllerTest {
 
         // Actual test
         request(mockParameters)
-        .andDo(print()).andExpect(status().isOk())
+        .andExpect(status().isOk())
         .andExpect(jsonPath("$._id").value("diagnosisResponseID"))
         .andExpect(jsonPath("$.etiology").value("etiology"))
         .andReturn();
@@ -99,7 +98,6 @@ public class DoseCalculationTest extends AntibioticsControllerTest {
         Mockito.doThrow(new InvalidParameterException(null)).when(validator).validate(any(), any());
 
         request(mockParameters)
-        .andDo(print())
         .andExpect(status().isBadRequest())
         .andReturn();
     }
@@ -110,7 +108,6 @@ public class DoseCalculationTest extends AntibioticsControllerTest {
         when(service.getDiagnosisInfoByID(any())).thenThrow(RuntimeException.class);
 
         request(mockParameters)
-        .andDo(print())
         .andExpect(status().isInternalServerError())
         .andReturn();
     }

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/service/AntibioticsServiceTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/service/AntibioticsServiceTest.java
@@ -1,4 +1,4 @@
-package fi.tuni.koodimankelit.antibiootit;
+package fi.tuni.koodimankelit.antibiootit.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/service/DataHandlerTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/service/DataHandlerTest.java
@@ -8,32 +8,33 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import fi.tuni.koodimankelit.antibiootit.database.DiagnosisRepository;
 import fi.tuni.koodimankelit.antibiootit.database.data.Diagnosis;
 import fi.tuni.koodimankelit.antibiootit.database.data.DiagnosisInfo;
 import fi.tuni.koodimankelit.antibiootit.exceptions.DiagnosisNotFoundException;
-import fi.tuni.koodimankelit.antibiootit.services.DataHandler;
+import fi.tuni.koodimankelit.antibiootit.services.DataHandlerImpl;
 
 
 /**
  * Tests for DataHandler service
  */
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class DataHandlerTest {
-    
-    @Autowired
-    private DataHandler dataHandler;
 
-    @MockBean
+    @Mock
     private DiagnosisRepository repository;
+    
+    @InjectMocks
+    private DataHandlerImpl dataHandler;
 
     /**
      * Test getDiagnosisById when searched object is found


### PR DESCRIPTION
Refactored existing tests: removed unused code & unnecessary prints

DataHandlerTest loaded whole application context. For some reason it connected to production database in Railway, even though the repository is mocked. For instance, if I disconnected from internet and ran the test, error occurred because no connection to railway could be made. To resolve this, more simple @Mock annotation is used, as @MockBean also loads whole application context (Spring Boot specific). Now the context is no more loaded and mocking works as intended.