### PR TITLE
Hide previous treatment results after changing diagnosis

### DIFF
--- a/frontend/antibiootit/src/components/Antibiotics.js
+++ b/frontend/antibiootit/src/components/Antibiotics.js
@@ -49,7 +49,7 @@ export default function Antibiotics() {
             setInstruction(infoTexts[STEP4]);
         }
 
-    const selected = diagnoses.filter(infection => infection.id === data.diagnosisID)[0];
+        const selected = diagnoses.filter(infection => infection.id === data.diagnosisID)[0];
 
         if (selected.needsAntibiotics) {
             setLoading(true);
@@ -78,11 +78,8 @@ export default function Antibiotics() {
             });
                 
         }
-        else if (data.diagnosisID !== 'J21.9') {
-            console.log("Bronkiitti valittu")
-        }
-        else if (data.diagnosisID !== 'J20.9') {
-            console.log("Obs. bronkiitti valittu")
+        else {
+            console.log("No need for antibiotic treatment")
         }
     }
 
@@ -101,6 +98,7 @@ export default function Antibiotics() {
             }
             else {
                 setNoAntibioticTreatment(null);
+                setFormSubmitted(false);
             }
         }
 

--- a/frontend/antibiootit/src/components/Form.js
+++ b/frontend/antibiootit/src/components/Form.js
@@ -106,16 +106,8 @@ export default function Form(props) {
         if(!props.formSubmitted) {
             props.changeInstruction(STEP2);
         }
-        
-        if (selectedInfo.needsAntibiotics === false) {
-            setNeedsAntibiotics(false);
-            const data = {
-                diagnosisID: selectedInfo.id
-            }
-            props.handleSubmit(data);
-            
-        }
-        else if (selectedInfo.needsAntibiotics === true) {
+
+        if (selectedInfo.needsAntibiotics === true) {
             setNeedsAntibiotics(true);
         }
         if (selected !== "Streptokokki-tonsilliitti") {
@@ -219,7 +211,6 @@ export default function Form(props) {
                                 penicillinAllergic: penicillinAllergy,
                                 checkBoxes: matchingCheckBoxes
                             }
-                console.log(data)
                 props.handleSubmit(data);
 
             }            

--- a/frontend/antibiootit/src/components/Treatment.js
+++ b/frontend/antibiootit/src/components/Treatment.js
@@ -5,7 +5,7 @@ import { InlineMath } from 'react-katex';
 import LoadingIndicator from "./LoadingIndicator";
 
 export default function Treatment(props) {
-    console.log(props.loading);
+    //console.log(props.loading);
 
     const [activeChoice, setActiveChoice] = useState(props.treatments[0]);
     const [activeVariables, setActiveVariables] = useState({


### PR DESCRIPTION
Korjaa ongelman, jossa aiempi antibioottihoitosuositus tuli näkyviin, jos välissä on valittu diagnoosi joka ei vaadi antibioottihoitoa. Nyt hoitosuositus- ja resepti-ikkunat poistuvat näkymästä kun bronkiitin jälkeen valitsee antibioottihoitoa vaativan diagnoosin (pitää painaa uudestaan Laske suositus, jotta _oikea_ hoitosuositus tulee näkyviin).