### PR TITLE
Fixed issue with selecting bronchitis first

### DIFF
--- a/frontend/antibiootit/src/components/Antibiotics.js
+++ b/frontend/antibiootit/src/components/Antibiotics.js
@@ -21,6 +21,7 @@ export default function Antibiotics() {
     const [chosenWeight, setChosenWeight] = useState(null);
     const [noAntibioticTreatment, setNoAntibioticTreatment] = useState(null);
     const [formData, setFormData] = useState(null);
+    const [hasFormData, setHasFormData] = useState(false)
     
     const [diagnoses, setDiagnoses] = useState(null);
     const [infoTexts, setInfoTexts] = useState(null);
@@ -63,6 +64,7 @@ export default function Antibiotics() {
 
         if (selected.needsAntibiotics) {
             setLoading(true);
+            setHasFormData(true);
             GetRecommendedTreatment(data)
             .then(response => {
                 setTreatments(response.treatments);
@@ -134,10 +136,12 @@ export default function Antibiotics() {
             if (chosenDiagnosis === 'Bronkiitti') {
                 setNoAntibioticTreatment({id: 'J21.9', text: infoTexts[14].text})
                 setFormSubmitted(true);
+                setLoading(false)
             }
             else if (chosenDiagnosis === 'Obstruktiivinen bronkiitti') {
                 setNoAntibioticTreatment({id: 'J20.9', text: infoTexts[15].text})
                 setFormSubmitted(true);
+                setLoading(false)
             }
             else {
                 setNoAntibioticTreatment(null);
@@ -164,6 +168,7 @@ export default function Antibiotics() {
                 setChosenWeight={setChosenWeight}
                 formSubmitted={formSubmitted} 
                 formData={formData}
+                hasFormData={hasFormData}
             />
             {formSubmitted && !!noAntibioticTreatment && <NoTreatment />}
             {formSubmitted && (treatments && diagnosisData.needsAntibiotics)  && <Treatment 

--- a/frontend/antibiootit/src/components/Form.js
+++ b/frontend/antibiootit/src/components/Form.js
@@ -106,14 +106,14 @@ export default function Form(props) {
         
         setFormatWeight(true);
         const selected = e.target.textContent;
+        
         const selectedInfo = fullInfo.filter(d => d.name === selected)[0]
         setDiagnosis(selectedInfo);
         props.setChosenDiagnosis(selected);
-        console.log(selectedInfo)
-        if(!props.formSubmitted) {
+        if(!props.formSubmitted || props.formData === null) {
             props.changeInstruction(STEP2);
         }
-        else if (props.formSubmitted && selectedInfo.id !== "J20.9" && selectedInfo.id !== "J21.9") {
+        else if (props.hasFormData && selectedInfo.id !== "J20.9" && selectedInfo.id !== "J21.9") {
             const checkBoxes = [
                 {
                     id: 'EBV-001',
@@ -128,12 +128,17 @@ export default function Form(props) {
                 return selectedInfo.checkBoxes.some(c => c.id === cb.id);
             });
 
-            const newData = {
-                ...props.formData,
-               diagnosisID: selectedInfo.id,
-               checkBoxes: matchingCheckBoxes
+            let newData = null;
+            
+            if (props.formData === null) {
+                console.log("no data")
             }
-
+            newData = {
+                    ...props.formData,
+                diagnosisID: selectedInfo.id,
+                checkBoxes: matchingCheckBoxes
+            }
+            
             props.handleSubmit(newData);
         }
 
@@ -180,7 +185,7 @@ export default function Form(props) {
             if (weightForCalculations >= MIN_WEIGHT && weightForCalculations <= MAX_WEIGHT) {
                 setIsWeightOk(true);
                 setFormatWeight(true);
-                if (props.formSubmitted) {
+                if (props.hasFormData) {
                     const newData = {
                         ...props.formData,
                         weight: weightForCalculations
@@ -276,14 +281,14 @@ export default function Form(props) {
             ...props.formData,
             penicillinAllergic: !penicillinAllergy
         }
-        if (props.formSubmitted) {
+        if (props.hasFormData) {
             props.handleSubmit(newData);
         }
         setPenicillinAllergy(!penicillinAllergy)
     }
 
     const handleEBV = () => {
-        if (props.formSubmitted) {
+        if (props.hasFormData) {
             const checkBoxes = [
                 {
                     id: 'EBV-001',
@@ -300,7 +305,7 @@ export default function Form(props) {
     }
 
     const handleMycoplasma = () => {
-        if (props.formSubmitted) {
+        if (props.hasFormData) {
             const checkBoxes = [
                 {
                     id: 'MYK-001',


### PR DESCRIPTION
Selecting bronchitis first caused the recipe component to stay in loading mode, and also broke the form submit data for further selections. These changes should fix the problem.