### PR TITLE
Test API weight as string

### DIFF
--- a/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
+++ b/backend/antibiootit/src/test/java/fi/tuni/koodimankelit/antibiootit/controller/DoseCalculationTest.java
@@ -94,6 +94,17 @@ public class DoseCalculationTest extends AntibioticsControllerTest {
     }
 
     @Test
+    public void stringWeightIsHandledCorrectly() throws Exception {
+        when(service.getDiagnosisInfoByID(any())).thenReturn(new DiagnosisInfo(null, null, null, new ArrayList<>(), true));
+        when(service.calculateTreatments(new Parameters("J03.0", 10.0, false, new ArrayList<>()))).thenReturn(new DiagnosisResponse(null, null, null));
+        String payload = "{\"diagnosisID\":\"J03.0\",\"penicillinAllergic\":false,\"weight\":\"10.0\",\"checkBoxes\":[]}";
+
+        request(payload)
+        .andExpect(status().isOk());
+
+    }
+
+    @Test
     public void validatorExceptionShouldReturn400() throws Exception {
 
         when(service.calculateTreatments(any()))


### PR DESCRIPTION
I noticed that frontend sends API requests with weight as string instead of JSON double. Created unit test to ensure string to double conversion works correctly